### PR TITLE
refactor: container atom을 사용하여 리팩토링

### DIFF
--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -1,9 +1,13 @@
-export default function Footer() {
+import Container from '@components/atoms/Container';
+
+function Footer() {
   return (
-    <footer className="w-full max-w-full bg-[#fafafc] p-7">
-      <div className="container mx-auto">
-        <p>@footer</p>
-      </div>
+    <footer>
+      <Container classes="p-7 bg-lighterGrey">
+        <p>&copy; 2024, linc-hackathon-1</p>
+      </Container>
     </footer>
   );
 }
+
+export default Footer;

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -1,12 +1,15 @@
+import Container from '@components/atoms/Container';
+
 type HeaderProps = {
   pageName: string;
 };
 
-const Header = ({ pageName }: HeaderProps) => {
+function Header({ pageName }: HeaderProps) {
   return (
-    <>
-      <div className="flex justify-between items-center w-full h-14 bg-white shadow-md border-b border-gray-200">
-        <button className="text-gray-700 pl-4">
+    <header>
+      <Container classes="h-[57px]">
+        {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
+        <button className="text-gray-700 pl-4 cursor-pointer" type="button">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -22,13 +25,14 @@ const Header = ({ pageName }: HeaderProps) => {
             />
           </svg>
         </button>
-        <div className="flex justify-center items-center flex-grow text-sm">
-          <div>{pageName}</div>
-        </div>
-        <div className="w-10"></div> {/* 오른쪽 빈 공간 */}
-      </div>
-    </>
+        <Container justifyContents="justify-center" alignItems="items-center" classes="flex-grow text-sm">
+          {pageName}
+        </Container>
+        <div className="w-10" />
+        {/* 오른쪽 빈 공간 */}
+      </Container>
+    </header>
   );
-};
+}
 
 export default Header;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,12 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
-import Header from "./components/organisms/Header.tsx";
-import "./index.css";
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import Header from '@components/organisms/Header';
+import './index.css';
+import Footer from '@components/organisms/Footer';
 
-createRoot(document.getElementById("root")!).render(
+createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <Header pageName={"지자체 상세보기"} />
-  </StrictMode>
+    <Header pageName="지자체 상세보기" />
+    <Footer />
+  </StrictMode>,
 );


### PR DESCRIPTION
Container을 사용하여 기존의 semantic 컴포넌트를 리팩토링 했습니다.

앞으로 페이지를 만드실 때에도 이걸 참조하면 좋을 것 같아요.

그리고, classes라는 prop은 항상 tailwind class명을 받도록 하려는데 어떨까요?

이렇게하면 IDE 설정을 통해 typehint를 받을 수 있어 매우 편리합니다.