### PR TITLE
Feat/network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,5 @@
+// eslint-disable-next-line import/prefer-default-export
+export const endpoints = {
+  UPLOAD_VIDEO: (provinceId: string) => `/api/video/${provinceId}`,
+  GET_VIDEO: (videoId: string) => `/api/video/${videoId}`,
+};

--- a/src/types/network/request.d.ts
+++ b/src/types/network/request.d.ts
@@ -1,0 +1,24 @@
+/**
+ * @export
+ * @interface VideoUploadRequestBody
+ */
+export interface VideoUploadRequestBody {
+
+  /**
+   * @type {string}
+   * @memberof VideoUploadRequestBody
+   */
+  title?: string;
+
+  /**
+   * @type {string}
+   * @memberof VideoUploadRequestBody
+   */
+  url?: string;
+
+  /**
+   * @type {string}
+   * @memberof VideoUploadRequestBody
+   */
+  description?: string;
+}

--- a/src/types/network/response.d.ts
+++ b/src/types/network/response.d.ts
@@ -1,0 +1,67 @@
+/**
+ * @export
+ * @interface ProvinceShortResponse
+ */
+export interface ProvinceShortResponse {
+
+  /**
+   * @type {string}
+   * @memberof ProvinceShortResponse
+   */
+  name?: string;
+
+  /**
+   * @type {string}
+   * @memberof ProvinceShortResponse
+   */
+  image?: string;
+}
+
+/**
+ * @export
+ * @interface VideoDetailResponse
+ */
+export interface VideoDetailResponse {
+
+  /**
+   * @type {string}
+   * @memberof VideoDetailResponse
+   */
+  id?: string;
+
+  /**
+   * @type {ProvinceShortResponse}
+   * @memberof VideoDetailResponse
+   */
+  province?: ProvinceShortResponse;
+
+  /**
+   * @type {string}
+   * @memberof VideoDetailResponse
+   */
+  title?: string;
+
+  /**
+   * @type {string}
+   * @memberof VideoDetailResponse
+   */
+  url?: string;
+
+  /**
+   * @type {number}
+   * @memberof VideoDetailResponse
+   */
+  likesCount?: number;
+
+  /**
+   * @type {number}
+   * @memberof VideoDetailResponse
+   */
+  repliesCount?: number;
+
+  /**
+   * @type {string}
+   * @memberof VideoDetailResponse
+   */
+  description?: string;
+}

--- a/src/utils/network/index.ts
+++ b/src/utils/network/index.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+const BASE_URL = import.meta.env.VITE_BASE_SERVER_URL;
+
+const axiosInstance = axios.create({
+  baseURL: BASE_URL,
+});
+
+export default axiosInstance;


### PR DESCRIPTION
request/response type을 정의했습니다.

아래와 같이 사용하시면 됩니다.

```typescript
import axiosInstance from '@utils/network';

axiosInstance.get<T>(...)
```

타입 파라미터 T는 Response Type을 넣으시면, response의 data 필드의 값이 해당 타입으로 추론됩니다.

그리고 배포 URL을 루트 폴더의 .env 파일에 아래 내용을 복붙해주시면 됩니다.
`VITE_BASE_SERVER_URL=https://port-0-dream-hackertone-lzqmsbqmec4d2284.sel4.cloudtype.app`

closes #12 
